### PR TITLE
Chapter 5

### DIFF
--- a/src/frontend/index.jsx
+++ b/src/frontend/index.jsx
@@ -7,5 +7,5 @@ import { Projection } from "./projection"
 require("./styling.css")
 
 createRoot(document.getElementById("root")).render(
-  <Projection astObject={observable(rental)} />
+  <Projection astObject={observable(rental)} ancestors={[]} />
 )

--- a/src/frontend/index.jsx
+++ b/src/frontend/index.jsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { observable } from "mobx"
 import { createRoot } from "react-dom/client"
 import rental from "../ch03/rental-AST"
 import { Projection } from "./projection"
@@ -6,5 +7,5 @@ import { Projection } from "./projection"
 require("./styling.css")
 
 createRoot(document.getElementById("root")).render(
-  <Projection astObject={rental} />
+  <Projection astObject={observable(rental)} />
 )

--- a/src/frontend/projection.jsx
+++ b/src/frontend/projection.jsx
@@ -2,7 +2,7 @@ import React from "react"
 import { observable } from "mobx"
 import { observer } from "mobx-react"
 import { isAstObject } from "../common/ast"
-import { TextValue } from "./value-components"
+import { DropDownValue, NumberValue, TextValue } from "./value-components"
 
 // A or an? This function will return what you need.
 const indefiniteArticleFor = nextWord =>
@@ -21,21 +21,21 @@ const indefiniteArticleFor = nextWord =>
 export const Projection = observer(({ astObject, parent }) => {
   if (isAstObject(astObject)) {
     const { settings } = astObject
+    const editStateFor = propertyName =>
+      observable({
+        value: settings[propertyName],
+        inEdit: false,
+        setValue: newValue => {
+          settings[propertyName] = newValue
+        },
+      })
     switch (astObject.concept) {
       case "Record Type":
         return (
           <div>
             <div>
               <span className="keyword ws-right">Record Type</span>
-              <TextValue
-                editState={observable({
-                  value: settings["name"],
-                  inEdit: false,
-                  setValue: newValue => {
-                    settings["name"] = value
-                  },
-                })}
-              />
+              <TextValue editState={editStateFor("name")} />
             </div>
             <div className="section">
               <div>
@@ -64,10 +64,15 @@ export const Projection = observer(({ astObject, parent }) => {
                 },
               })}
             />
+            {/* This selects the `is a` or `is an` value for us. */}
             <span className="keyword ws-both">
               is {indefiniteArticleFor(settings["type"])}
             </span>
-            <span className="value enum-like ws-right">{settings["type"]}</span>
+            <DropDownValue
+              className="value enum-like ws-right"
+              editState={editStateFor("type")}
+              options={["amount", "date range", "percentage"]}
+            />
             {settings["initialValue"] && (
               <div className="inline">
                 <span className="keyword ws-right">initially</span>
@@ -96,7 +101,7 @@ export const Projection = observer(({ astObject, parent }) => {
         return (
           <div className="inline">
             {type === "amount" && <span className="keyword">$</span>}
-            <span className="value">{settings["value"]}</span>
+            <NumberValue editState={editStateFor("value")} />
             {type === "percentage" && <span className="keyword">%</span>}
           </div>
         )

--- a/src/frontend/projection.jsx
+++ b/src/frontend/projection.jsx
@@ -1,5 +1,8 @@
 import React from "react"
+import { observable } from "mobx"
+import { observer } from "mobx-react"
 import { isAstObject } from "../common/ast"
+import { TextValue } from "./value-components"
 
 // A or an? This function will return what you need.
 const indefiniteArticleFor = nextWord =>
@@ -15,7 +18,7 @@ const indefiniteArticleFor = nextWord =>
  * it's referencing is an Amount or a Percentage because in the UI you'd have to know which symbol
  * ($ or %) to show!
  */
-export const Projection = ({ astObject, parent }) => {
+export const Projection = observer(({ astObject, parent }) => {
   if (isAstObject(astObject)) {
     const { settings } = astObject
     switch (astObject.concept) {
@@ -24,7 +27,15 @@ export const Projection = ({ astObject, parent }) => {
           <div>
             <div>
               <span className="keyword ws-right">Record Type</span>
-              <span className="value">Rental</span>
+              <TextValue
+                editState={observable({
+                  value: settings["name"],
+                  inEdit: false,
+                  setValue: newValue => {
+                    settings["name"] = value
+                  },
+                })}
+              />
             </div>
             <div className="section">
               <div>
@@ -44,7 +55,15 @@ export const Projection = ({ astObject, parent }) => {
         return (
           <div className="attribute">
             <span className="keyword ws-right">the</span>
-            <span className="value">{settings["name"]}</span>
+            <TextValue
+              editState={observable({
+                value: settings["name"],
+                inEdit: false,
+                setValue: newValue => {
+                  settings["name"] = newValue
+                },
+              })}
+            />
             <span className="keyword ws-both">
               is {indefiniteArticleFor(settings["type"])}
             </span>
@@ -90,4 +109,4 @@ export const Projection = ({ astObject, parent }) => {
         )
     }
   }
-}
+})

--- a/src/frontend/projection.jsx
+++ b/src/frontend/projection.jsx
@@ -13,12 +13,12 @@ const indefiniteArticleFor = nextWord =>
  * a DFS over the ast. The projection part means that it's mapping the AST to some UI
  * layer, in this case html via react.
  *
- * We have a parent object as well, because sometimes you need access to the parent
+ * We have a list of ancestor objects as well, because sometimes you need access to the parent
  * node from the child as in the case of a Number object. You'd need to know if the thing
  * it's referencing is an Amount or a Percentage because in the UI you'd have to know which symbol
  * ($ or %) to show!
  */
-export const Projection = observer(({ astObject, parent }) => {
+export const Projection = observer(({ astObject, ancestors }) => {
   if (isAstObject(astObject)) {
     const { settings } = astObject
     const editStateFor = propertyName =>
@@ -44,7 +44,7 @@ export const Projection = observer(({ astObject, parent }) => {
               {settings["attributes"].map((attribute, index) => (
                 <Projection
                   astObject={attribute}
-                  parent={astObject}
+                  ancestors={[astObject, ...ancestors]}
                   key={index}
                 />
               ))}
@@ -78,21 +78,44 @@ export const Projection = observer(({ astObject, parent }) => {
                 <span className="keyword ws-right">initially</span>
                 <Projection
                   astObject={settings["initialValue"]}
-                  parent={astObject}
+                  ancestors={[astObject, ...ancestors]}
                 />
               </div>
             )}
           </div>
         )
-      case "Attribute Reference":
+      case "Attribute Reference": {
+        // We have to find the attributes for the CURRENT record type in
+        // order to list them out. So for example, maybe for a Rental type
+        // the attributes are different from something like a Vehicle type.
+        const recordType = ancestors.find(
+          ancestor => ancestor.concept === "Record Type"
+        )
+        // Now we can get all the attributes for the current record type (e.g., Rental)
+        // because we'd want to know which attribute this was referencing right?
+        // For example, if this value was referencing the rental_price_before_discount
+        // then wouldn't it make sense that the initial value should be the referent's initial value?
+        // You wouldn't want to mess that up and put a string for an initial value that should be a number right?
+        const attributes = recordType.settings["attributes"]
         return (
           <div className="inline">
             <span className="keyword ws-right">the</span>
-            <span className="reference">
-              {settings["attribute"].ref.settings["name"]}
-            </span>
+            <DropDownValue
+              editState={observable({
+                value: settings["attribute"].ref.settings["name"],
+                inEdit: false,
+                setValue: newValue => {
+                  settings["attribute"].ref = attributes.find(
+                    attribute => attribute.settings["name"] === newValue
+                  )
+                },
+              })}
+              className="reference"
+              options={attributes.map(attribute => attribute.settings["name"])}
+            />
           </div>
         )
+      }
       case "Number": {
         const type =
           parent &&

--- a/src/frontend/styling.css
+++ b/src/frontend/styling.css
@@ -50,3 +50,15 @@ span.reference {
   color: blue;
   text-decoration: underline;
 }
+
+input {
+  font-size: 12pt;
+  border-radius: 5px;
+  border: 3px solid yellow;
+  background-color: lightyellow;
+  padding-left: 5px;
+}
+
+input:focus {
+  outline: none;
+}

--- a/src/frontend/styling.css
+++ b/src/frontend/styling.css
@@ -62,3 +62,7 @@ input {
 input:focus {
   outline: none;
 }
+
+select {
+  font-size: 12pt;
+}

--- a/src/frontend/value-components.jsx
+++ b/src/frontend/value-components.jsx
@@ -1,0 +1,50 @@
+import React from "react"
+import { action } from "mobx"
+import { observer } from "mobx-react"
+
+/**
+ * Represents a book.
+ * @typedef {Object} EditState
+ * @property {string} value - The value of the thing being edited
+ * @property {boolean} inEdit - Whether or not the TextValue component should be in edit mode.
+ */
+
+/**
+ * Represents an editable value in the ast.
+ * @component
+ * @param {EditState} editState The editState object representing the string to be edited in the ast.
+ * @returns {React.ReactElement}
+ */
+export const TextValue = observer(({ editState }) =>
+  editState.inEdit ? (
+    <input
+      type="text"
+      defaultValue={editState.value}
+      autoFocus={true}
+      onBlur={action(event => {
+        const newValue = event.target.value
+        editState.setValue(newValue)
+        editState.inEdit = false
+      })}
+      onKeyUp={action(event => {
+        if (event.key === "Enter") {
+          const newValue = event.target.value
+          editState.setValue(newValue)
+          editState.inEdit = false
+        }
+        if (event.key === "Escape") {
+          editState.inEdit = false
+        }
+      })}
+    />
+  ) : (
+    <span
+      className="value"
+      onClick={action(_ => {
+        editState.inEdit = true
+      })}
+    >
+      {editState.value}
+    </span>
+  )
+)


### PR DESCRIPTION
## Explanation

This chapter focused on being able to *edit* the projected ast.

It introduced the notion of *value components* and *edit state* that could be switched on or off depending on certain user actions.

We also covered a particularly tricky area: editing initial values for reference types. If you had a new attribute that was a reference type to some other attribute, the question is: "Wouldn't you want to know what the type of the initial value would be?". You wouldn't want to have an attribute that referenced a: `rental_price_before_discount` that has a number value and give the initial value a string instead. It wouldn't make any sense.

## What I've Learned

- Using observers is probably the most natural way to implement these composable edit states
- The AST being editable is exactly what makes the projectional editor so valuable. Things like dropdowns that enable the domain expert to choose from finite lists is enormously helpful instead of them having to memorize this.